### PR TITLE
Use experimental BentoSearch::ConcurrentSearcher from repo branch.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'jbuilder', '~> 2.5'
 
 # Gems added for fordham law search app specifically:
 # temporarily point bento_search to master
-gem 'bento_search', git: 'https://github.com/jrochkind/bento_search.git' # '~> 1.6'
+gem 'bento_search', git: 'https://github.com/jrochkind/bento_search.git', branch: "concurrent_searcher" # '~> 1.6'
 gem 'slim-rails', '~> 3.1'
 gem 'concurrent-ruby', '~>1.0'
 gem 'kaminari' # pagination

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,8 @@ GIT
 
 GIT
   remote: https://github.com/jrochkind/bento_search.git
-  revision: de5bbd9ab9065917474fc9e804227eacf5b73935
+  revision: 43902b40735644ae56952a7f51c127fa1da99161
+  branch: concurrent_searcher
   specs:
     bento_search (1.7.0.beta.1)
       confstruct (~> 1.0)


### PR DESCRIPTION
Handles Rails5 concurrent autoloading properly, among other things