### PR TITLE
Reserves search uses new SierraCombinedBrowseEngine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'bento_search', git: 'https://github.com/jrochkind/bento_search.git' #, bran
 gem 'slim-rails', '~> 3.1'
 gem 'concurrent-ruby', '~>1.0'
 gem 'kaminari' # pagination
+gem 'addressable', '~> 2.5' # completing partial URLs
 
 # heroku suggested, see config/rack_timeout.rb
 gem "rack-timeout"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
     arel (7.1.4)
     autoprefixer-rails (6.5.3)
       execjs
@@ -145,6 +147,7 @@ GEM
     openurl (1.0.0)
       marc
       scrub_rb (~> 1.0)
+    public_suffix (2.0.5)
     puma (3.6.0)
     rack (2.0.1)
     rack-test (0.6.3)
@@ -242,6 +245,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  addressable (~> 2.5)
   autoprefixer-rails
   bento_search!
   byebug

--- a/app/assets/javascripts/google_analytics_offsite_links.js
+++ b/app/assets/javascripts/google_analytics_offsite_links.js
@@ -1,6 +1,4 @@
 function _gaLt(event){
-    debugger
-
     var el = event.srcElement || event.target;
 
     /* Loop up the DOM tree through parent elements if clicked element is not a link (eg: an image inside a link) */

--- a/app/search_engines/sierra_browse_engine.rb
+++ b/app/search_engines/sierra_browse_engine.rb
@@ -1,0 +1,137 @@
+# A screen-scraper for Sierra 'browse' style searches. it's pretty hacky.
+#
+# * Only fills out 'title' of returned results, that's all we got.
+# * Does left-anchored 'browse' style search only, as it's scraping Sierra browse.
+# * Does not set `total_items`, as this info is not available from Sierra browse scrape.
+#
+# # Required configuration
+# * 'search_type', sierra "search_type" param, `p` for Prof/TA, or `r` for (reserves) Course
+#
+# # Optional configuration
+#  * `max_results` can always only return whatever the page size is on Webpac, at
+#     most. But set this to limit to even less.
+#  * `base_url` defaults to http://lawpac.lawnet.fordham.edu
+#  * `format_str` hard-coded string to use as format, ie "Professor/TA" or "Course"
+
+
+class SierraBrowseEngine
+  include BentoSearch::SearchEngine
+
+  extend HTTPClientPatch::IncludeClient
+
+  class_attribute :http_timeout
+  self.http_timeout = 8
+
+  include_http_client do |client|
+    client.connect_timeout = client.send_timeout = client.receive_timeout = self.http_timeout
+  end
+
+  def self.default_configuration
+    {
+      # Using https oddly messes up non-ascii on the way in and way out,
+      # seems to get confused between UTF-8 and WINDOWS-1252. Don't have
+      # this problem with http version. Weird proxy issues on Webpac end?
+      base_url: "http://lawpac.lawnet.fordham.edu"
+    }
+  end
+
+
+  def search_implementation(args)
+    scrape_url = construct_search_url(args)
+    response = http_client.get(scrape_url)
+
+    unless response.ok?
+      error = BentoSearch::Results.new
+      error.error = {
+        status: response.status,
+        response: response.body
+      }
+      fill_in_search_metadata_for(error, args)
+
+      return error
+    end
+
+    results = BentoSearch::Results.new
+
+    document = Nokogiri::HTML(response.body)
+
+    base_url = Addressable::URI.parse(scrape_url)
+
+    if no_results?(document)
+      results.total_items = 0
+    elsif result = extract_single_result(document, base_url: base_url, query: args[:query])
+      results << result
+    else # browse screen
+      document.css("td.browseEntryData a:not(:empty)").each do |link|
+        result =  BentoSearch::ResultItem.new(
+          title: link.text,
+          link: (base_url + link["href"]).to_s
+        )
+        results << result
+      end
+    end
+
+    if configuration.format_str
+      results.each { |r| r.format_str = configuration.format_str }
+    end
+
+    results
+  end
+
+  def no_results?(doc)
+    !!(doc.text =~ /No matches found/)
+  end
+
+  # Sierra returns a weird bib page if there's only ONE result, we need to
+  # do some RIDICULOUS shenanigans to get the single phrase hit out
+  def extract_single_result(doc, base_url: base_url, query: query)
+    # does it have the single-page search feedback thing on it?
+    if doc.at_css("td.bibInfoData")
+      # Need to find the right line of data, from the echo'd back search type,
+      # seriously.
+      label = doc.at_css("select[name=searchtype] option[selected=selected]").text.strip
+
+      # We have to pull out the possible <tr> rows it's crazy
+
+
+      bib_info_data_rows = doc.xpath("//tr[child::td[@class='bibInfoData']/a]")
+      # We need to find the ones with a bibInfoLabel matching our label OR,
+      # with no bibInfoLabel as long as they're BEFORE the next bibInfoLabel
+      in_range = false
+      value_rows = []
+      bib_info_data_rows.each do |row|
+        if label_td = row.at_css("td.bibInfoLabel")
+          if !in_range && label_td.text.strip.downcase == label.strip.downcase
+            in_range = true
+          elsif in_range
+            break
+          end
+        end
+
+        value_rows << row if in_range
+      end
+
+      # Which of the value rows starts with the query, or the first one if none match
+      hit_row = value_rows.find do |tr|
+        tr.at_css("td.bibInfoData").try { |n| n.text.strip.downcase.start_with?(query.downcase) }
+      end || value_rows.first
+
+      if hit_row && hit_link = hit_row.at_css("td.bibInfoData a")
+        return BentoSearch::ResultItem.new(
+          title: hit_link.text.strip,
+          link: (base_url + hit_link["href"]).to_s
+        )
+      end
+    end
+  end
+
+  def construct_search_url(args)
+    # http://lawpac.lawnet.fordham.edu/search/a?searchtype=p&searcharg=query
+
+    "#{configuration.base_url}/search/a?searchtype=#{configuration.search_type}&searcharg=#{CGI.escape args[:query]}"
+  end
+
+  def self.required_configuration
+    %w{search_type}
+  end
+end

--- a/app/search_engines/sierra_browse_engine.rb
+++ b/app/search_engines/sierra_browse_engine.rb
@@ -125,7 +125,9 @@ class SierraBrowseEngine
       if hit_row && hit_link = hit_row.at_css("td.bibInfoData a")
         return BentoSearch::ResultItem.new(
           title: hit_link.text.strip,
-          link: (base_url + hit_link["href"]).to_s
+          # using the actual link['href'] goes to a weird place, use the base_url
+          # that got us here to single result page.
+          link: (base_url).to_s
         )
       end
     end

--- a/app/search_engines/sierra_browse_engine.rb
+++ b/app/search_engines/sierra_browse_engine.rb
@@ -62,7 +62,13 @@ class SierraBrowseEngine
     elsif result = extract_single_result(document, base_url: base_url, query: args[:query])
       results << result
     else # browse screen
+      i = 0
+
       document.css("td.browseEntryData a:not(:empty)").each do |link|
+        i += 1
+
+        break if configuration.max_results && i > configuration.max_results
+
         result =  BentoSearch::ResultItem.new(
           title: link.text,
           link: (base_url + link["href"]).to_s

--- a/app/search_engines/sierra_browse_engine.rb
+++ b/app/search_engines/sierra_browse_engine.rb
@@ -84,7 +84,7 @@ class SierraBrowseEngine
 
   # Sierra returns a weird bib page if there's only ONE result, we need to
   # do some RIDICULOUS shenanigans to get the single phrase hit out
-  def extract_single_result(doc, base_url: base_url, query: query)
+  def extract_single_result(doc, base_url:, query:)
     # does it have the single-page search feedback thing on it?
     if doc.at_css("td.bibInfoData")
       # Need to find the right line of data, from the echo'd back search type,

--- a/app/search_engines/sierra_browse_engine.rb
+++ b/app/search_engines/sierra_browse_engine.rb
@@ -58,7 +58,7 @@ class SierraBrowseEngine
     base_url = Addressable::URI.parse(scrape_url)
 
     if no_results?(document)
-      results.total_items = 0
+      # nothing
     elsif result = extract_single_result(document, base_url: base_url, query: args[:query])
       results << result
     else # browse screen

--- a/app/search_engines/sierra_combined_browse_engine.rb
+++ b/app/search_engines/sierra_combined_browse_engine.rb
@@ -1,0 +1,27 @@
+#require 'bento_search/concurrent_searcher'
+
+# A weird search engine that merges results from multiple SierraBrowseEngines,
+# sorting alphabetically and limiting to max_results.
+class SierraCombinedBrowseEngine
+  include BentoSearch::SearchEngine
+
+  def search_implementation(args)
+    searcher = BentoSearch::ConcurrentSearcher.new(*configuration.component_engine_ids)
+
+    searcher.search(args[:query])
+
+    master_results = BentoSearch::Results.new
+
+    searcher.results.each_pair do |id, results|
+      master_results.concat results
+      if results.failed?
+        master_results.error = results.error
+      end
+    end
+
+    master_results.total_items = nil
+    master_results.sort_by! {|i| i.title.downcase }
+
+    return master_results
+  end
+end

--- a/app/search_engines/sierra_keyword_engine.rb
+++ b/app/search_engines/sierra_keyword_engine.rb
@@ -87,10 +87,7 @@ class SierraKeywordEngine
     document = Nokogiri::HTML(response.body)
 
     results = BentoSearch::Results.new
-
-    if results.total_items == 0
-      # nothing
-    elsif single_result_page?(document)
+    if single_result_page?(document)
       results.total_items = extract_single_total_items(document)
       item = SingleItemExtractor.new(document, configuration).extract
       if item

--- a/config/initializers/bento_search.rb
+++ b/config/initializers/bento_search.rb
@@ -103,18 +103,47 @@ BentoSearch.register_engine("articles") do |conf|
   end
 end
 
+# BentoSearch.register_engine("reserves") do |conf|
+#   conf.allow_routable_results = true
+
+#   conf.engine = "SierraKeywordEngine"
+#   conf.query_suffix = " (inCourseReserve)"
+#   conf.max_results = 3
+
+#   conf.for_display do |display|
+#     display.ajax = :auto
+#     display.heading = "Course Reserves/Exams"
+#     display.link_out = "http://lawpac.lawnet.fordham.edu/search/X?%28%s%20%28inCourseReserve%29%29&SORT=R&Da=&Db="
+#   end
+# end
+
+# This engine isn't exposed directly, but used by the reserves combo-searcher
+BentoSearch.register_engine("reserves_prof") do |conf|
+  conf.engine = "SierraBrowseEngine"
+  conf.search_type = "p"
+  conf.format_str = "Professor/TA"
+end
+
+# This engine isn't exposed directly, but used by the reserves combo-searcher
+BentoSearch.register_engine("reserves_course") do |conf|
+  conf.engine = "SierraBrowseEngine"
+  conf.search_type = "r"
+  conf.max_results = 3
+
+  conf.format_str = "Course"
+end
+
 BentoSearch.register_engine("reserves") do |conf|
   conf.allow_routable_results = true
+  conf.engine = "SierraCombinedBrowseEngine"
 
-  conf.engine = "SierraKeywordEngine"
-  conf.query_suffix = " (inCourseReserve)"
-  conf.max_results = 3
+  conf.component_engine_ids = ["reserves_prof", "reserves_course"]
 
   conf.for_display do |display|
     display.ajax = :auto
     display.heading = "Course Reserves/Exams"
-    display.link_out = "http://lawpac.lawnet.fordham.edu/search/X?%28%s%20%28inCourseReserve%29%29&SORT=R&Da=&Db="
   end
+
 end
 
 BentoSearch.register_engine("databases") do |conf|

--- a/spec/search_engines/sierra_browse_engine_spec.rb
+++ b/spec/search_engines/sierra_browse_engine_spec.rb
@@ -32,6 +32,16 @@ describe SierraBrowseEngine do
         expect(Addressable::URI.parse(result.link)).to be_absolute
       end
     end
+
+    describe "with limit" do
+      let(:max_results) { 1 }
+      let(:engine) { SierraBrowseEngine.new(max_results: max_results, id: "mock", search_type: search_type, format_str: format_str) }
+      it "returns results within max" do
+        results = engine.search(query)
+        expect(results.failed?).not_to be(true)
+        expect(results.size).to eq(max_results)
+      end
+    end
   end
 
   describe "one result" do

--- a/spec/search_engines/sierra_browse_engine_spec.rb
+++ b/spec/search_engines/sierra_browse_engine_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+describe SierraBrowseEngine do
+  let(:search_type) { "p" }
+  let(:format_str) { "Some Thing" }
+  let(:engine) { SierraBrowseEngine.new(id: "mock", search_type: search_type, format_str: format_str) }
+
+  describe "no results" do
+    let(:query) { "adzzzzzzzzakdjfzzzzz" }
+
+    it "returns no results" do
+      results = engine.search(query)
+      expect(results.failed?).not_to be(true)
+      expect(results.size).to eq(0)
+    end
+  end
+
+  describe "multiple results" do
+    let(:query) { "s" }
+
+    it "returns results" do
+      results = engine.search(query)
+      expect(results.failed?).not_to be(true)
+      expect(results.size > 0).to be(true)
+      results.each do |result|
+        expect(result.title).to be_present
+        expect(result.title.downcase.start_with?(query)).to be(true)
+
+        expect(result.format_str).to eq(format_str)
+
+        expect(result.link).to be_present
+        expect(Addressable::URI.parse(result.link)).to be_absolute
+      end
+    end
+  end
+
+  describe "one result" do
+    # Sierra jumps straight to bib record when there's only one hit
+    let(:query) { "silverstein" }
+
+    it "Returns one result" do
+      results = engine.search(query)
+      expect(results.failed?).not_to be(true)
+      expect(results.size).to eq(1)
+
+      result = results.first
+
+      expect(result.title).to be_present
+      expect(result.title.downcase.start_with?(query)).to be(true)
+
+      expect(result.format_str).to eq(format_str)
+
+      expect(result.link).to be_present
+      expect(Addressable::URI.parse(result.link)).to be_absolute
+    end
+  end
+
+end


### PR DESCRIPTION
combining two searches using new SierraBrowseEngine, scraping
professor name and course name reserves browse searches.