### PR TITLE
changed EDS cat and article linkouts so yellow guest bar hidden

### DIFF
--- a/config/initializers/bento_search.rb
+++ b/config/initializers/bento_search.rb
@@ -34,8 +34,9 @@ BentoSearch.register_engine("catalog") do |conf|
     #display.hint = "Library books, journals, music, videos, databases, archival collections, and online resources"
     #display.link_out = "http://encore.lawnet.fordham.edu/iii/encore/search?formids=target&lang=eng&suite=def&reservedids=lang%2Csuite&target=%s"
     #display.link_out ="http://search.ebscohost.com/login.aspx?authtype=IP,cookie,guest&custid=s8944740&groupid=main&profile=eds&direct=true&cli0=FC&clv0=Y&bquery=%s"
-    display.link_out ="http://search.ebscohost.com/login.aspx?authtype=IP,cookie,guest&custid=s8944740&groupid=main&profile=edscatonly&direct=true&bquery=%s"
-    display.link_out_text "View and filter all %i catalog results"
+    # previous linkout: display.link_out ="http://search.ebscohost.com/login.aspx?authtype=IP,cookie,guest&custid=s8944740&groupid=main&profile=edscatonly&direct=true&bquery=%s"
+    display.link_out ="http://search.ebscohost.com/login.aspx?authtype=IP,guest&custid=s8944740&groupid=main&profile=edscatonly&direct=true&bquery=%s"
+	display.link_out_text "View and filter all %i catalog results"
 
     display.year_only = true
 
@@ -82,8 +83,8 @@ BentoSearch.register_engine("articles") do |conf|
     display.heading = "Articles"
     #display.hint = "Articles, e-books, dissertations, music, images, and more from a mostly full-text database"
     #display.link_out = "http://encore.lawnet.fordham.edu/iii/encore/eds/C__S%s__Orightresult__U"
-    display.link_out ="http://search.ebscohost.com/login.aspx?authtype=IP,cookie,guest&custid=s8944740&groupid=main&profile=edsnocat&direct=true&bquery=%s"
-
+    # previous linkout: display.link_out ="http://search.ebscohost.com/login.aspx?authtype=IP,cookie,guest&custid=s8944740&groupid=main&profile=edsnocat&direct=true&bquery=%s"
+	display.link_out ="http://search.ebscohost.com/login.aspx?authtype=IP,guest&custid=s8944740&groupid=main&profile=edsnocat&direct=true&bquery=%s"
     display.ajax = :auto
 
     display.extra_links_label = "Additional Resources"


### PR DESCRIPTION
removes "cookie" syntax from urls.  Chad at ebsco is hiding the guest access bar and the url changes are necessary for the links to work.